### PR TITLE
Replace `require` for `NFS.load(path)()`, and add `.lua` at the end of…

### DIFF
--- a/paperback.lua
+++ b/paperback.lua
@@ -13,7 +13,7 @@
 
 _RELEASE_MODE = false -- DEBUG MODE :: REMOVE IN RELEASE
 
-PB_UTIL = require(SMODS.current_mod.path .. "/paperback-utils")
+PB_UTIL = NFS.load(SMODS.current_mod.path .. "/paperback-utils.lua")()
 
 -- Registers the atlas for Jokers
 SMODS.Atlas {  
@@ -32,7 +32,7 @@ local CONFIG = {
 for key, enabled in pairs(CONFIG) do
     if enabled then
         local path = key:gsub("_", "/", 1)
-        require(SMODS.current_mod.path .. "/" .. path) -- name files "joker_<name>" so they get loaded automatically
+        NFS.load(SMODS.current_mod.path .. "/" .. path .. ".lua")() -- name files "joker_<name>" so they get loaded automatically
         sendDebugMessage("Paperback :: Loaded joker: " .. key)
     end
 end


### PR DESCRIPTION
Replaces all instances of the `require()` function for `NFS.load(path)()` due to code changes. The `require()` function suddenly stopped working correctly, and this workaround was suggested to me by a member on the Discord server.