### PR TITLE
Prevent Nachos from being eaten multiple times

### DIFF
--- a/joker/nachos.lua
+++ b/joker/nachos.lua
@@ -45,45 +45,44 @@ SMODS.Joker {
             return
         end
 
-        -- Penalize when discarding cards
-        if context.discard then
-            if not context.blueprint then
-                -- Destroy Nachos if value is <= 1
-                if card.ability.extra.X_chips - card.ability.extra.reduction_amount <= 1 then
-                    G.E_MANAGER:add_event(Event({
-                        func = function()
-                            play_sound('tarot1')
-                            card.T.r = -0.2
-                            card:juice_up(0.3, 0.4)
-                            card.states.drag.is = true
-                            card.children.center.pinch.x = true
-                            G.E_MANAGER:add_event(Event({
-                                trigger = 'after',
-                                delay = 0.3,
-                                blockable = false,
-                                func = function()
-                                    G.jokers:remove_card(card)
-                                    card:remove()
-                                    card = nil
-                                    return true;
-                                end
-                            }))
-                            return true
-                        end
-                    }))
-                    return {
-                        message = localize('k_eaten_ex'),
-                        colour = G.C.FILTER
-                    }
-                else
-                    -- Reduce the xChips value
-                    card.ability.extra.X_chips = card.ability.extra.X_chips - card.ability.extra.reduction_amount
-                    return {
-                        delay = 0.2,
-                        message = localize { type = 'variable', key = 'a_xmult_minus', vars = { card.ability.extra.reduction_amount } },
-                        colour = G.C.CHIPS
-                    }
-                end
+        -- Penalize discarding cards only when the current mult is higher than 1
+        if context.discard and not context.blueprint and card.ability.extra.X_chips > 1 then
+            -- Reduce the xChips value
+            card.ability.extra.X_chips = card.ability.extra.X_chips - card.ability.extra.reduction_amount
+
+            -- Destroy Nachos if the current value is <= 1
+            if card.ability.extra.X_chips <= 1 then
+                G.E_MANAGER:add_event(Event({
+                    func = function()
+                        play_sound('tarot1')
+                        card.T.r = -0.2
+                        card:juice_up(0.3, 0.4)
+                        card.states.drag.is = true
+                        card.children.center.pinch.x = true
+                        G.E_MANAGER:add_event(Event({
+                            trigger = 'after',
+                            delay = 0.3,
+                            blockable = false,
+                            func = function()
+                                G.jokers:remove_card(card)
+                                card:remove()
+                                card = nil
+                                return true;
+                            end
+                        }))
+                        return true
+                    end
+                }))
+                return {
+                    message = localize('k_eaten_ex'),
+                    colour = G.C.FILTER
+                }
+            else
+                return {
+                    delay = 0.2,
+                    message = localize { type = 'variable', key = 'a_xmult_minus', vars = { card.ability.extra.reduction_amount } },
+                    colour = G.C.CHIPS
+                }
             end
         end
     end


### PR DESCRIPTION
Previously, when the value of Nachos was, for example, `1.05X` and the player discards 2 or more cards, the eaten text would pop up multiple times