### PR TITLE
Migrate from headers to metadata

### DIFF
--- a/joker/cakepop.lua
+++ b/joker/cakepop.lua
@@ -73,10 +73,11 @@ SMODS.Joker {
                                     local jokers_to_create = math.min(1,
                                         G.jokers.config.card_limit - (#G.jokers.cards + G.GAME.joker_buffer))
                                     G.GAME.joker_buffer = G.GAME.joker_buffer + jokers_to_create
-                                    
+
                                     G.E_MANAGER:add_event(Event({
                                         func = function()
-                                            local card = create_card('Joker', G.jokers, nil, 0, nil, nil, 'j_pape_pop_stick', nil)
+                                            local card = create_card('Joker', G.jokers, nil, 0, nil, nil,
+                                                'j_paperback_pop_stick', nil)
                                             card:add_to_deck()
                                             G.jokers:emplace(card)
                                             card:start_materialize()

--- a/joker/caramel_apple.lua
+++ b/joker/caramel_apple.lua
@@ -77,7 +77,7 @@ SMODS.Joker {
                                     G.E_MANAGER:add_event(Event({
                                         func = function()
                                             local card = create_card('Joker', G.jokers, nil, 0, nil, nil,
-                                                'j_pape_pointy_stick', nil)
+                                                'j_paperback_pointy_stick', nil)
                                             card:add_to_deck()
                                             G.jokers:emplace(card)
                                             card:start_materialize()

--- a/joker/charred_marshmallow.lua
+++ b/joker/charred_marshmallow.lua
@@ -77,7 +77,7 @@ SMODS.Joker {
                                     G.E_MANAGER:add_event(Event({
                                         func = function()
                                             local card = create_card('Joker', G.jokers, nil, 0, nil, nil,
-                                                'j_pape_sticky_stick', nil)
+                                                'j_paperback_sticky_stick', nil)
                                             card:add_to_deck()
                                             G.jokers:emplace(card)
                                             card:start_materialize()
@@ -108,4 +108,3 @@ SMODS.Joker {
         end
     end
 }
-

--- a/joker/dreamsicle.lua
+++ b/joker/dreamsicle.lua
@@ -73,10 +73,11 @@ SMODS.Joker {
                                     local jokers_to_create = math.min(1,
                                         G.jokers.config.card_limit - (#G.jokers.cards + G.GAME.joker_buffer))
                                     G.GAME.joker_buffer = G.GAME.joker_buffer + jokers_to_create
-                                    
+
                                     G.E_MANAGER:add_event(Event({
                                         func = function()
-                                            local card = create_card('Joker', G.jokers, nil, 0, nil, nil, 'j_pape_popsicle_stick', nil)
+                                            local card = create_card('Joker', G.jokers, nil, 0, nil, nil,
+                                                'j_paperback_popsicle_stick', nil)
                                             card:add_to_deck()
                                             G.jokers:emplace(card)
                                             card:start_materialize()

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,5 @@
     "main_file": "paperback.lua",
     "badge_colour": "8b61ad",
     "version": "0.3.1",
-    "dependencies": ["Steamodded (>=1.0.0~)", "Lovely (>=0.6)"]
+    "dependencies": ["Steamodded (>=1.0.0~ALPHA-1203b)", "Lovely (>=0.6)"]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "paperback",
+    "name": "Paperback",
+    "prefix": "paperback",
+    "author": ["PaperMoon", "Nether", "OppositeWolf770", "B"],
+    "description": "A vanilla centered mod built upon expanding the base game with jokers",
+    "main_file": "paperback.lua",
+    "badge_colour": "8b61ad",
+    "version": "0.3.1",
+    "dependencies": ["Steamodded (>=1.0.0~)", "Lovely (>=0.6)"]
+}

--- a/paperback-utils.lua
+++ b/paperback-utils.lua
@@ -24,14 +24,14 @@ local set_cost_ref = Card.set_cost
 function Card.set_cost(self)
     if G.STAGE == G.STAGES.RUN and self.added_to_deck then
         -- If this card is Union Card, set sell cost to 0
-        if self.config.center.key == "j_pape_union_card" then
+        if self.config.center.key == "j_paperback_union_card" then
             self.sell_cost = 0
             return
         end
 
         -- If the player has Union Card, set sell cost to 0
         for k, v in ipairs(G.jokers.cards) do
-            if v.config.center.key == "j_pape_union_card" then
+            if v.config.center.key == "j_paperback_union_card" then
                 self.sell_cost = 0
                 return
             end
@@ -79,7 +79,7 @@ CardArea.remove_card = function(self, card, discarded_only)
         -- Apply effects to Sacrificial Lamb and Unholy Alliance since the card removed is a joker
         for k, v in ipairs(G.jokers.cards) do
             if card.ability.set == 'Joker' then
-                if v.config.center_key == 'j_pape_sacrificial_lamb' then
+                if v.config.center_key == 'j_paperback_sacrificial_lamb' then
                     v.ability.extra.mult = v.ability.extra.mult + v.ability.extra.mult_mod
 
                     SMODS.eval_this(v, {
@@ -89,7 +89,7 @@ CardArea.remove_card = function(self, card, discarded_only)
                             vars = { v.ability.extra.mult_mod }
                         }
                     })
-                elseif v.config.center_key == 'j_pape_unholy_alliance' then
+                elseif v.config.center_key == 'j_paperback_unholy_alliance' then
                     v.ability.extra.xMult = v.ability.extra.xMult + v.ability.extra.xMult_gain
 
                     SMODS.eval_this(v, {

--- a/paperback.lua
+++ b/paperback.lua
@@ -1,12 +1,3 @@
---- STEAMODDED HEADER
---- MOD_NAME: Paperback
---- MOD_ID: paperback
---- MOD_AUTHOR: [PaperMoon, Nether, OppositeWolf770, B]
---- MOD_DESCRIPTION: A vanilla centered mod built upon expanding the base game with jokers
---- LOADER_VERSION_GEQ: 1.0.0
---- VERSION: 0.3.1
---- BADGE_COLOR: 8b61ad
-
 PB_UTIL = NFS.load(SMODS.current_mod.path .. "/paperback-utils.lua")()
 
 -- -- Loads the JokerDisplay


### PR DESCRIPTION
Headers are considered outdated in the [Steamodded wiki](https://github.com/Steamopollys/Steamodded/wiki/Mod-Metadata) and the new metadata system is encouraged.

The main change this brings to this project is that the prefix no longer has a default value of the first 4 characters of the mod id, so I've changed it here from `pape` to `paperback`