### PR TITLE
Make Paranoia's tooltip not super wide

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -356,7 +356,8 @@ return {
       j_paperback_paranoia = {
         name = "Paranoia",
         text = {
-          "After scoring a hand, destroy all {C:Dark_suit}dark suits{} played",
+          "After scoring a hand,",
+          "destroy all {C:Dark_suit}dark suits{} played",
           "and all {C:Light_suit}light suits{} held in hand",
         },
       },


### PR DESCRIPTION
It's litterally just an extra line break because it was bothering me in game (especially when next to vanilla jokers who keep their tooltips thin).

Before:
![1](https://github.com/user-attachments/assets/1a2a50d1-a970-4e66-af94-571eeb0b51eb)
After:
![2](https://github.com/user-attachments/assets/8781ec8d-1e17-436a-b44b-dfecd222ce95)
