### PR TITLE
Add Food pool

### DIFF
--- a/joker/apple.lua
+++ b/joker/apple.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   eternal_compat = false,
   perishable_compat = true,
   soul_pos = { x = 7, y = 6 },
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = G.P_CENTERS.e_negative

--- a/joker/cakepop.lua
+++ b/joker/cakepop.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   eternal_compat = false,
   soul_pos = nil,
   yes_pool_flag = "cakepop_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/caramel_apple.lua
+++ b/joker/caramel_apple.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   eternal_compat = false,
   soul_pos = nil,
   yes_pool_flag = "caramel_apple_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/champagne.lua
+++ b/joker/champagne.lua
@@ -14,6 +14,9 @@ SMODS.Joker {
   discovered = true,
   blueprint_compat = true,
   eternal_compat = false,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/charred_marshmallow.lua
+++ b/joker/charred_marshmallow.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   eternal_compat = false,
   soul_pos = nil,
   yes_pool_flag = "charred_marshmallow_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/coffee.lua
+++ b/joker/coffee.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   blueprint_compat = false,
   eternal_compat = false,
   soul_pos = nil,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/complete_breakfast.lua
+++ b/joker/complete_breakfast.lua
@@ -18,6 +18,9 @@ SMODS.Joker {
   blueprint_compat = true,
   eternal_compat = false,
   soul_pos = nil,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/cream_liqueur.lua
+++ b/joker/cream_liqueur.lua
@@ -15,6 +15,9 @@ SMODS.Joker {
   blueprint_compat = true,
   eternal_compat = false,
   soul_pos = nil,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/crispy_taco.lua
+++ b/joker/crispy_taco.lua
@@ -17,6 +17,9 @@ SMODS.Joker {
   soul_pos = nil,
 
   no_pool_flag = "soft_taco_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/dreamsicle.lua
+++ b/joker/dreamsicle.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   eternal_compat = false,
   soul_pos = nil,
   yes_pool_flag = "dreamsicle_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/epic_sauce.lua
+++ b/joker/epic_sauce.lua
@@ -14,6 +14,9 @@ SMODS.Joker {
   blueprint_compat = true,
   eternal_compat = true,
   perishable_compat = true,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/ghost_cola.lua
+++ b/joker/ghost_cola.lua
@@ -12,6 +12,9 @@ SMODS.Joker {
   soul_pos = nil,
 
   yes_pool_flag = "ghost_cola_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = G.P_TAGS.tag_negative

--- a/joker/joker_cookie.lua
+++ b/joker/joker_cookie.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
   blueprint_compat = false,
   eternal_compat = false,
   soul_pos = nil,
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/joker/nachos.lua
+++ b/joker/nachos.lua
@@ -15,6 +15,9 @@ SMODS.Joker {
   blueprint_compat = true,
   eternal_compat = false,
   soul_pos = nil,
+  pools = {
+    Food = true
+  },
 
   set_ability = function(self, card, initial, delay_sprites)
     card.ability.extra.X_chips = card.ability.extra.X_chips or 1

--- a/joker/soft_taco.lua
+++ b/joker/soft_taco.lua
@@ -17,6 +17,9 @@ SMODS.Joker {
   soul_pos = nil,
 
   yes_pool_flag = "soft_taco_can_spawn",
+  pools = {
+    Food = true
+  },
 
   loc_vars = function(self, info_queue, card)
     return {

--- a/paperback-utils.lua
+++ b/paperback-utils.lua
@@ -51,6 +51,41 @@ SMODS.current_mod.config_tab = function()
   }
 end
 
+-- Initialize Food pool if not existing, which may be created by other mods.
+-- Any joker can add itself to this pool by adding a pools table to its definition
+-- Credits to Cryptid for the idea
+if not SMODS.ObjectTypes.Food then
+  SMODS.ObjectType {
+    key = 'Food',
+    default = 'j_egg',
+    cards = {},
+    inject = function(self)
+      SMODS.ObjectType.inject(self)
+      -- Insert base game food jokers
+      self:inject_card(G.P_CENTERS.j_gros_michel)
+      self:inject_card(G.P_CENTERS.j_egg)
+      self:inject_card(G.P_CENTERS.j_ice_cream)
+      self:inject_card(G.P_CENTERS.j_cavendish)
+      self:inject_card(G.P_CENTERS.j_turtle_bean)
+      self:inject_card(G.P_CENTERS.j_diet_cola)
+      self:inject_card(G.P_CENTERS.j_popcorn)
+      self:inject_card(G.P_CENTERS.j_ramen)
+      self:inject_card(G.P_CENTERS.j_selzer)
+    end
+  }
+end
+
+function PB_UTIL.is_food(card)
+  -- Accepts a key, a center or a card
+  local key = (type(card) == "string" and card) or (card.key and card.key) or card.config.center_key
+
+  if key then
+    for _, v in ipairs(G.P_CENTER_POOLS.Food) do
+      if v.key == key then return true end
+    end
+  end
+end
+
 -- Define light and dark suits
 PB_UTIL.light_suits = { 'Diamonds', 'Hearts' }
 PB_UTIL.dark_suits = { 'Spades', 'Clubs' }
@@ -591,29 +626,6 @@ if (SMODS.Mods["Bunco"] or {}).can_load then
 
   table.insert(PB_UTIL.light_suits, prefix .. '_Fleurons')
   table.insert(PB_UTIL.dark_suits, prefix .. '_Halberds')
-end
-
--- If Cryptid is also loaded, add food jokers to pool for ://SPAGHETTI
-if (SMODS.Mods["Cryptid"] or {}).can_load then
-  local food_jokers = {
-    "cakepop",
-    "caramel_apple",
-    "charred_marshmallow",
-    "crispy_taco",
-    "dreamsicle",
-    "ghost_cola",
-    "joker_cookie",
-    "nachos",
-    "soft_taco",
-    "complete_breakfast",
-    "coffee",
-    "cream_liqueur",
-    "epic_sauce"
-  }
-
-  for k, v in ipairs(food_jokers) do
-    table.insert(Cryptid.food, "j_paperback_" .. v)
-  end
 end
 
 return PB_UTIL


### PR DESCRIPTION
This provides us a way to:
- Create food jokers
- Check if a joker is food
- Allows cross-mod compatibility (any joker can add itself to this pool and use this pool to spawn food jokers)

The `Cryptid.food` table is no longer used by Cryptid, instead they also use a Food pool, which is where I got the idea from.