### PR TITLE
Add utility function for changing a card's sell value

### DIFF
--- a/joker/hole_in_one.lua
+++ b/joker/hole_in_one.lua
@@ -27,29 +27,13 @@ SMODS.Joker {
     if context.end_of_round and not (context.individual or context.repetition) and not context.blueprint then
       if G.GAME.current_round.hands_played == 1 then
         -- Double all Joker sell values
-        for index, v in ipairs(G.jokers.cards) do
-          if card.set_cost then
-            if v.custom_sell_cost then
-              v.custom_sell_cost_increase = v.sell_cost
-            else
-              v.ability.extra_value = (v.ability.extra_value or 0)
-                  + (v.sell_cost > card.ability.extra.money_max and card.ability.extra.money_max or v.sell_cost)
-            end
-            v:set_cost()
-          end
+        for _, v in ipairs(G.jokers.cards) do
+          PB_UTIL.modify_sell_value(v, math.min(v.sell_cost, card.ability.extra.money_max))
         end
 
         -- Double all Consumeable sell values
-        for index, v in ipairs(G.consumeables.cards) do
-          if card.set_cost then
-            if v.custom_sell_cost then
-              v.custom_sell_cost_increase = v.sell_cost
-            else
-              v.ability.extra_value = (v.ability.extra_value or 0)
-                  + (v.sell_cost > card.ability.extra.money_max and card.ability.extra.money_max or v.sell_cost)
-            end
-            v:set_cost()
-          end
+        for _, v in ipairs(G.consumeables.cards) do
+          PB_UTIL.modify_sell_value(v, math.min(v.sell_cost, card.ability.extra.money_max))
         end
 
         return {
@@ -62,7 +46,7 @@ SMODS.Joker {
     -- Set all sell values to 0 when selling this Joker
     if context.selling_self and not context.blueprint then
       -- Resets all Jokers' sell values
-      for index, v in ipairs(G.jokers.cards) do
+      for _, v in ipairs(G.jokers.cards) do
         if v ~= card then
           if v.set_cost then
             v.ability.extra_value = 0
@@ -73,7 +57,7 @@ SMODS.Joker {
       end
 
       -- Resets all consumeables' sell values
-      for index, v in ipairs(G.consumeables.cards) do
+      for _, v in ipairs(G.consumeables.cards) do
         if v.set_cost then
           v.ability.extra_value = 0
           v.zero_sell_cost = true

--- a/joker/wish_you_were_here.lua
+++ b/joker/wish_you_were_here.lua
@@ -49,14 +49,7 @@ SMODS.Joker {
 
       -- Increase the sell value at end of round
       if context.end_of_round and not context.blueprint then
-        if card.set_cost then
-          if card.custom_sell_cost then
-            card.custom_sell_cost_increase = 1
-          else
-            card.ability.extra_value = (card.ability.extra_value or 0) + 1
-          end
-          card:set_cost()
-        end
+        PB_UTIL.modify_sell_value(card, 1)
 
         return {
           message = localize('k_val_up'),

--- a/paperback-utils.lua
+++ b/paperback-utils.lua
@@ -108,7 +108,7 @@ function Card.set_cost(self)
 
   -- Don't calculate the original sell_cost calculation if a custom sell_cost increase has been indicated
   if self.custom_sell_cost then
-    self.sell_cost = self.sell_cost + (self.custom_sell_cost_increase or 1)
+    self.sell_cost = self.sell_cost + (self.custom_sell_cost_increase or 0)
     self.custom_sell_cost_increase = nil
   else
     set_cost_ref(self)
@@ -175,6 +175,18 @@ function level_up_hand(card, hand, instant, amount)
   })
 
   return ret
+end
+
+function PB_UTIL.modify_sell_value(card, amount)
+  if not card.set_cost or amount == 0 then return end
+
+  if card.custom_sell_cost then
+    card.custom_sell_cost_increase = amount
+  else
+    card.ability.extra_value = (card.ability.extra_value or 0) + amount
+  end
+
+  card:set_cost()
 end
 
 function PB_UTIL.calculate_stick_xMult(card)


### PR DESCRIPTION
Additionally, this fixes a bug where "Wish You Were Here" would double its sell value at all times when paired with "Hole In One"