### PR TITLE
Mod compatability fix for Rapture

### DIFF
--- a/utilities/hooks.lua
+++ b/utilities/hooks.lua
@@ -275,11 +275,10 @@ function G.FUNCS.get_poker_hand_info(_cards)
     local has_apostle = false
     local all_top = true
     for i = 1, #scoring_hand do
-      local rank = not SMODS.has_no_rank(scoring_hand[i]) and SMODS.Ranks[scoring_hand[i].base.value]
-      if rank.key == 'paperback_Apostle' then has_apostle = true end
-      if rank.key ~= 'Ace' and rank.key ~= 'paperback_Apostle' and not rank.face then all_top = false end
+      local rank = SMODS.Ranks[scoring_hand[i].base.value]
+      has_apostle = has_apostle or rank.key == 'paperback_Apostle'
+      all_top = all_top and (rank.key == 'paperback_Apostle' or rank.key == 'Ace' or rank.face)
     end
-
     if has_apostle and all_top then
       disp_text = "paperback_Straight Flush (Rapture)"
       loc_disp_text = localize(disp_text, "poker_hands")
@@ -374,7 +373,7 @@ function pseudorandom_element(_t, seed, args)
     if v == SMODS.ConsumableTypes['paperback_ego_gift']
     or (
       type(v) == 'table' and
-        (v.set == "paperback_ego_gift" or v.key == "c_paperback_golden_bough"))
+      (v.set == "paperback_ego_gift" or v.key == "c_paperback_golden_bough"))
     then
       table.insert(keys_to_remove, k)
     end
@@ -384,7 +383,6 @@ function pseudorandom_element(_t, seed, args)
   end
   return pseudorandom_element_ref(_t, seed, args)
 end
-
 
 -- WhiteNight is indestructible
 -- Currently doesn't do much because WhiteNight always


### PR DESCRIPTION
Changes:
- Fixed potential nil reference and mod compatibility issues when attempting to name a Rapture.

Note:  This was rewritten to match more closely with the way that Royal Flushes are generated.  I'm not sure why it was checking for no no_ranks, but it doesn't seem to affect anything else in there, and it causes crashes in Cryptid.