### PR TITLE
Fixing JJJJ issues with non-integers

### DIFF
--- a/content/joker/jimbos_joyous_joker_jamboree.lua
+++ b/content/joker/jimbos_joyous_joker_jamboree.lua
@@ -58,7 +58,7 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.individual and context.cardarea == G.play then
-      if G.GAME.paperback.jjjj_count % card.ability.extra.required == 0 then
+      if G.GAME.paperback.jjjj_count % card.ability.extra.required < 1 then
         if PB_UTIL.try_spawn_card { set = 'paperback_minor_arcana', } then
           return {
             message = localize('paperback_plus_minor_arcana'),


### PR DESCRIPTION
Changes:
- Fixes Jimbo's Joyous Joker Jamboree when scored cards is non-integer.

JJJJ will trigger inconsistently if the required number of cards to play are non-integers.

For example, if the required cards becomes 16.2, it should require 17 cards to trigger.  This previously would not trigger until 81 cards had been played, since 17 % 16.2 = 0.8 and 81 % 16.2 = 0.  Thus, changing the trigger condition to < 1 should fix these issues by checking the entire range of [0, 1).