### PR TITLE
Add Reference Card poker hands reference on card

### DIFF
--- a/content/joker/reference_card.lua
+++ b/content/joker/reference_card.lua
@@ -17,11 +17,22 @@ SMODS.Joker {
   soul_pos = nil,
 
   loc_vars = function(self, info_queue, card)
+    local hands_to_play = ""
+
+    for _, hand in ipairs(PB_UTIL.base_poker_hands) do
+      local current_hand = G.GAME.hands[hand]
+
+      if current_hand.played <= G.GAME.paperback.reference_card_ct then
+        hands_to_play = hands_to_play .. (hands_to_play == '' and ' ' or ', ') .. localize(hand, 'poker_hands')
+      end
+    end
+
     local x_mult = card.ability.extra.x_mult_mod * G.GAME.paperback.reference_card_ct + card.ability.extra.x_mult
     return {
       vars = {
         card.ability.extra.x_mult_mod,
-        x_mult
+        x_mult,
+        hands_to_play,
       }
     }
   end,

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1534,6 +1534,7 @@ return {
           "Gives {X:mult,C:white}X#1#{} Mult for every time {C:attention}all{} 9",
           "base {C:attention}poker hands{} have been played",
           "{C:inactive}(Currently {X:mult,C:white}X#2#{} {C:inactive}Mult)",
+          "{C:inactive}(Hands to play:{C:attention}#3#{C:inactive})",
         },
       },
       j_paperback_dreamsicle = {


### PR DESCRIPTION
Changes:
- Add in which hands need to be played to upgrade Reference Card.

This change should make using this card easier for those that don't want to do math and also might want to more easily identify how easy it is to upgrade. I think the only downside is that it can get kinda big when all the poker hands are waiting. Perhaps finding a way to split this using `main_end` instead?
<img width="1279" height="575" alt="image" src="https://github.com/user-attachments/assets/bd4fe379-7ac8-4afd-9cbb-6f3d6dbd9585" />
