### PR TITLE
roulette.lua check for unlock fix

### DIFF
--- a/content/joker/roulette.lua
+++ b/content/joker/roulette.lua
@@ -23,7 +23,15 @@ SMODS.Joker {
   check_for_unlock = function(self, args)
     if args.type == 'hand_contents' then
       local eval = evaluate_poker_hand(args.cards)
-      if next(eval['paperback_Spectrum Five']) then
+      local has_spectrum_five = false
+      for hand, contents in pairs(eval) do
+        if string.find(hand, 'Spectrum Five') then
+          if next(eval[hand]) then
+            has_spectrum_five = true
+          end
+        end
+      end
+      if has_spectrum_five then
         return true
       end
     end


### PR DESCRIPTION
hand "Paperback_Spectrum Five" may not necessarily exist, as per `cross-mod.lua`, spectrum items are not loaded if they already are present (due to Bunco, Sixsuits, or SpectrumFramework). Otherwise, game crashes trying to evaluate:

```
[SMODS paperback "content/joker/roulette.lua"]:27: attempt to call a table value
```