### PR TITLE
ease_dollars fix with Talisman-type numbers

### DIFF
--- a/utilities/hooks.lua
+++ b/utilities/hooks.lua
@@ -425,10 +425,10 @@ end
 -- Used by Coin Collection to add dollars
 local ease_dollars_ref = ease_dollars
 function ease_dollars(mod, instant)
-  if mod > 0 and next(SMODS.find_card("j_paperback_coin_collection")) then
+  if to_big(mod) > to_big(0) and next(SMODS.find_card("j_paperback_coin_collection")) then
     for _, c in ipairs(SMODS.find_card("j_paperback_coin_collection")) do
-      mod = mod + c.ability.extra.dollars
-      SMODS.calculate_effect({message = "+$" .. c.ability.extra.dollars}, c)
+      mod = to_big(mod) + to_big(c.ability.extra.dollars)
+      SMODS.calculate_effect({ message = "+$" .. c.ability.extra.dollars }, c)
     end
   end
   return ease_dollars_ref(mod, instant)


### PR DESCRIPTION
In the creation of [this issue](https://github.com/Balatro-Paperback/paperback/issues/293), think I figured out the problem. Essentially `mod` and `0` (and for coin_collection `c.ability.extra.dollars`) need to be Talisman-ish numbers.