### PR TITLE
Change PB_UTIL.is_paperclip to use a lookup table

### DIFF
--- a/utilities/definitions/paperclips.lua
+++ b/utilities/definitions/paperclips.lua
@@ -13,14 +13,10 @@ PB_UTIL.ENABLED_PAPERCLIPS = {
   "platinum_clip"
 }
 
-PB_UTIL.PAPERCLIP_SET = {}
-for _, v in ipairs(PB_UTIL.ENABLED_PAPERCLIPS) do
-  PB_UTIL.PAPERCLIP_SET["paperback_" .. v] = true
-end
-
 if PB_UTIL.config.paperclips_enabled then
   -- Table to hold all paperclip keys regardless of mod of origin for easy reference
   PB_UTIL.Paperclips = {}
+  PB_UTIL.Paperclips_keys = {}
 
   PB_UTIL.Paperclip = SMODS.Sticker:extend {
     prefix_config = { key = true },
@@ -36,6 +32,7 @@ if PB_UTIL.config.paperclips_enabled then
 
     inject = function(self, i)
       SMODS.Sticker.inject(self, i)
+      PB_UTIL.Paperclips_keys[self.key] = true
       table.insert(PB_UTIL.Paperclips, self.key)
     end,
 

--- a/utilities/definitions/paperclips.lua
+++ b/utilities/definitions/paperclips.lua
@@ -13,6 +13,11 @@ PB_UTIL.ENABLED_PAPERCLIPS = {
   "platinum_clip"
 }
 
+PB_UTIL.PAPERCLIP_SET = {}
+for _, v in ipairs(PB_UTIL.ENABLED_PAPERCLIPS) do
+  PB_UTIL.PAPERCLIP_SET["paperback_" .. v] = true
+end
+
 if PB_UTIL.config.paperclips_enabled then
   -- Table to hold all paperclip keys regardless of mod of origin for easy reference
   PB_UTIL.Paperclips = {}

--- a/utilities/misc_functions.lua
+++ b/utilities/misc_functions.lua
@@ -43,12 +43,7 @@ end
 ---@param str string
 ---@return boolean
 function PB_UTIL.is_paperclip(str)
-  for _, v in ipairs(PB_UTIL.Paperclips or {}) do
-    if v == str then
-      return true
-    end
-  end
-  return false
+  return PB_UTIL.PAPERCLIP_SET[str] == true
 end
 
 ---Checks if a card has a paperclip. If found, the first value returned is the key.

--- a/utilities/misc_functions.lua
+++ b/utilities/misc_functions.lua
@@ -43,7 +43,7 @@ end
 ---@param str string
 ---@return boolean
 function PB_UTIL.is_paperclip(str)
-  return PB_UTIL.PAPERCLIP_SET[str] == true
+  return PB_UTIL.Paperclips_keys[str] == true
 end
 
 ---Checks if a card has a paperclip. If found, the first value returned is the key.


### PR DESCRIPTION
This should improve performance by making it so checking for a paperclip is a single call rather than a loop.