### PR TITLE
use SMODS.scale_card for everything

### DIFF
--- a/content/joker/57_leaf_clover.lua
+++ b/content/joker/57_leaf_clover.lua
@@ -39,11 +39,14 @@ SMODS.Joker {
         card.ability.extra.current = 1
         return { message = localize('k_reset') }
       else
-        card.ability.extra.current = card.ability.extra.current + card.ability.extra.gain
-        return {
-          message = localize('paperback_plus_odds'),
-          colour = G.C.GREEN,
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'current',
+          scalar_value = 'gain',
+          message_key = 'paperback_plus_odds',
+          message_colour = G.C.GREEN
+        })
+        return nil, true
       end
     end
   end

--- a/content/joker/57_leaf_clover.lua
+++ b/content/joker/57_leaf_clover.lua
@@ -43,7 +43,7 @@ SMODS.Joker {
           ref_table = card.ability.extra,
           ref_value = 'current',
           scalar_value = 'gain',
-          message_key = 'paperback_plus_odds',
+          message_key = 'paperback_a_odds',
           message_colour = G.C.GREEN
         })
         return nil, true

--- a/content/joker/attacking_vertical.lua
+++ b/content/joker/attacking_vertical.lua
@@ -49,11 +49,13 @@ SMODS.Joker {
       end
     end
     if context.end_of_round and context.main_eval and context.beat_boss and not context.blueprint then
-      card.ability.extra.xm = card.ability.extra.xm + card.ability.extra.change
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.MULT
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xm',
+        scalar_value = 'change',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
   end
 }

--- a/content/joker/black_forest_cake.lua
+++ b/content/joker/black_forest_cake.lua
@@ -45,12 +45,13 @@ SMODS.Joker {
     end
 
     if not context.blueprint and context.end_of_round and context.main_eval then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-      return {
-        message = localize('k_upgrade_ex'),
-        card = card,
-        colour = G.C.MULT,
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'a_mult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
 
     if not context.blueprint and PB_UTIL.count_destroyed_things(context) > 0

--- a/content/joker/blue_marble.lua
+++ b/content/joker/blue_marble.lua
@@ -36,10 +36,12 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.using_consumeable and context.consumeable.ability.set == "Planet" then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.increment
-      return {
-        message = localize('k_upgrade_ex')
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'increment'
+      })
+      return nil, true
     end
 
     if context.joker_main then

--- a/content/joker/calling_card.lua
+++ b/content/joker/calling_card.lua
@@ -38,26 +38,26 @@ SMODS.Joker {
     -- Upgrade joker if boss blind defeated
     if context.end_of_round and context.main_eval and not context.blueprint then
       if G.GAME.blind.boss then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.Xmult_mod
-
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.MULT,
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'Xmult_mod',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 
     -- Upgrade joker if boss blind triggered
     if context.debuffed_hand and not context.blueprint then
       if G.GAME.blind.triggered then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.Xmult_mod
-
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.MULT,
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'Xmult_mod',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/chip_clip.lua
+++ b/content/joker/chip_clip.lua
@@ -45,14 +45,18 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if not context.blueprint and context.individual and context.cardarea == G.hand and context.end_of_round then
       if PB_UTIL.has_paperclip(context.other_card) and not context.other_card.debuff then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.a_chips
-
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.CHIPS,
-          message_card = card,
-          juice_card = context.other_card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'a_chips',
+          scaling_message = {
+            message = localize('k_upgrade_ex'),
+            colour = G.C.CHIPS,
+            message_card = card,
+            juice_card = context.other_card
+          }
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/chocolate_coins.lua
+++ b/content/joker/chocolate_coins.lua
@@ -32,14 +32,18 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.starting_shop and context.cardarea == G.jokers then
-      card.ability.extra.enabled = true
-      card.ability.extra.dollars = card.ability.extra.dollars - card.ability.extra.eaten
-      if card.ability.extra.dollars <= 0 then
+      if card.ability.extra.dollars - card.ability.extra.eaten <= 0 then
         PB_UTIL.destroy_joker(card)
-        return {
-          message = localize('k_eaten_ex'),
-          colour = G.C.FILTER
-        }
+        return { message = localize('k_eaten_ex') }
+      else
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'dollars',
+          scalar_value = 'eaten',
+          operation = '-',
+          no_message = true
+        })
+        return nil, true
       end
     end
   end,

--- a/content/joker/claw.lua
+++ b/content/joker/claw.lua
@@ -41,7 +41,12 @@ SMODS.Joker {
         local mult = card.ability.extra.mult
 
         if not context.blueprint then
-          card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_inc
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'mult',
+            scalar_value = 'mult_inc',
+            no_message = true
+          })
         end
 
         return {

--- a/content/joker/coffee.lua
+++ b/content/joker/coffee.lua
@@ -56,12 +56,16 @@ SMODS.Joker {
 
     if context.skip_blind then
       -- Increment the hand size when skipping a blind
-      card.ability.extra.hand_size = card.ability.extra.hand_size + card.ability.extra.increase
-      G.hand:change_size(card.ability.extra.increase)
-
-      return {
-        message = localize('k_upgrade_ex')
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'hand_size',
+        scalar_value = 'increase',
+        operation = function(ref_table, ref_value, initial, change)
+          ref_table[ref_value] = initial + change
+          G.hand:change_size(change)
+        end,
+      })
+      return nil, true
     end
 
     if context.setting_blind and not context.blind.boss then

--- a/content/joker/complete_breakfast.lua
+++ b/content/joker/complete_breakfast.lua
@@ -5,7 +5,8 @@ SMODS.Joker {
       mult = 5,
       chips = 50,
       odds = 8,
-      chance_multiplier = 1
+      chance_multiplier = 1,
+      chance_inc = 1,
     }
   },
   attributes = {
@@ -80,8 +81,12 @@ SMODS.Joker {
           colour = G.C.MULT
         }
       else
-        card.ability.extra.chance_multiplier = card.ability.extra.chance_multiplier + 1
-
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chance_multiplier',
+          scalar_value = 'chance_inc',
+          no_message = true,
+        })
         return {
           message = localize('k_safe_ex'),
           colour = G.C.CHIPS,

--- a/content/joker/deck_of_cards.lua
+++ b/content/joker/deck_of_cards.lua
@@ -49,12 +49,13 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if not context.blueprint and context.before and #context.full_hand == 1 then
       if SMODS.has_enhancement(context.scoring_hand[1], card.ability.extra.enhancement) then
-        card.ability.extra.x_chips = card.ability.extra.x_chips + card.ability.extra.Xchips_mod
         card.ability.extra.active = true
-
-        return {
-          message = localize('k_upgrade_ex'),
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_chips',
+          scalar_value = 'Xchips_mod'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/der_fluschutze.lua
+++ b/content/joker/der_fluschutze.lua
@@ -39,12 +39,13 @@ SMODS.Joker {
     --Increase mult counter if card is a face
     if not context.blueprint and context.before and #context.full_hand == 1 then
       if G.GAME.current_round.hands_played == 0 and context.scoring_hand[1]:is_face() then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.Xmult_mod
         card.ability.extra.active = true
-
-        return {
-          message = localize('k_upgrade_ex'),
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'Xmult_mod'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/derecho.lua
+++ b/content/joker/derecho.lua
@@ -44,13 +44,13 @@ SMODS.Joker {
         bad_suit = bad_suit or PB_UTIL.is_non_suit(v, 'dark')
       end
       if not bad_suit then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.x_mult_mod
-
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.MULT,
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'x_mult_mod',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/disco.lua
+++ b/content/joker/disco.lua
@@ -21,11 +21,12 @@ SMODS.Joker {
   end,
   calculate = function(self, card, context)
     if not context.blueprint and context.buying_card and to_big(G.GAME.dollars) <= to_big(card.ability.extra.dollars) and context.card ~= card then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.ORANGE
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_mod'
+      })
+      return nil, true
     end
     if context.joker_main then
       return {

--- a/content/joker/freight.lua
+++ b/content/joker/freight.lua
@@ -45,12 +45,18 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.end_of_round and G.GAME.blind.boss and context.main_eval and not context.blueprint then
-      card.ability.extra_value = (card.ability.extra_value or 0) + card.ability.extra.gain
+      SMODS.scale_card(card, {
+        ref_table = card.ability,
+        ref_value = 'extra_value',
+        scalar_table = card.ability.extra,
+        scalar_value = 'gain',
+        scaling_message = {
+          message = localize('k_val_up'),
+          colour = G.C.MONEY
+        }
+      })
       card:set_cost()
-      return {
-        message = localize('k_val_up'),
-        colour = G.C.MONEY
-      }
+      return nil, true
     end
     if context.selling_self and not context.blueprint then
       local discards = card.ability.extra.discards * math.floor(card.sell_cost / card.ability.extra.per_dollar)

--- a/content/joker/furioso.lua
+++ b/content/joker/furioso.lua
@@ -73,14 +73,16 @@ SMODS.Joker {
 
         if rank and not card.ability.extra.ranks[rank] then
           card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.x_mult_mod
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'x_mult',
+            scalar_value = 'x_mult_mod',
+            message_colour = G.C.MULT
+          })
           card.ability.extra.ranks[rank] = context.other_card.base.value
           -- recalc ranks_sorted
           card.ability.extra.ranks_sorted = nil
-
-          return {
-            extra = { focus = card, message = localize('k_upgrade_ex'), colour = G.C.MULT },
-            card = card,
-          }
+          return nil, true
         end
       end
     end

--- a/content/joker/furioso.lua
+++ b/content/joker/furioso.lua
@@ -77,12 +77,15 @@ SMODS.Joker {
             ref_table = card.ability.extra,
             ref_value = 'x_mult',
             scalar_value = 'x_mult_mod',
-            message_colour = G.C.MULT
+            no_message = true
           })
           card.ability.extra.ranks[rank] = context.other_card.base.value
           -- recalc ranks_sorted
           card.ability.extra.ranks_sorted = nil
-          return nil, true
+          return {
+            extra = { focus = card, message = localize('k_upgrade_ex'), colour = G.C.MULT },
+            card = card,
+          }
         end
       end
     end

--- a/content/joker/giga_size.lua
+++ b/content/joker/giga_size.lua
@@ -45,7 +45,12 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if not context.blueprint and context.before then
-      card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xmult',
+        scalar_value = 'xmult_mod',
+        no_message = true
+      })
     end
 
     if context.joker_main then

--- a/content/joker/greeting_card.lua
+++ b/content/joker/greeting_card.lua
@@ -47,13 +47,18 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.individual and context.cardarea == G.play and not context.blueprint then
       if SMODS.has_enhancement(context.other_card, card.ability.extra.enhancement) then
-        PB_UTIL.modify_sell_value(card, card.ability.extra.a_value)
-
-        return {
-          focus = card,
-          message = localize('k_val_up'),
-          colour = G.C.MONEY
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability,
+          ref_value = 'extra_value',
+          scalar_table = card.ability.extra,
+          scalar_value = 'a_value',
+          scaling_message = {
+            message = localize('k_val_up'),
+            colour = G.C.MONEY
+          }
+        })
+        card:set_cost()
+        return nil, true
       end
     end
   end

--- a/content/joker/high_speed_rail.lua
+++ b/content/joker/high_speed_rail.lua
@@ -44,31 +44,32 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if not context.blueprint and context.selling_card and context.card ~= card then
       if context.card.ability.set == 'Joker' and context.card.sell_cost ~= 0 then
-        card.ability.extra.mult = math.max(0, card.ability.extra.mult - context.card.sell_cost)
-
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult_minus',
-            vars = { context.card.sell_cost }
-          },
-          colour = G.C.MULT
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_table = context.card,
+          scalar_value = 'sell_cost',
+          operation = function(ref_table, ref_value, initial, scaling)
+            ref_table[ref_value] = math.max(0, initial - scaling)
+          end,
+          message_key = 'a_mult_minus',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 
     if not context.blueprint and context.buying_card and context.card ~= card then
       if context.card.ability.set == 'Joker' and context.card.cost ~= 0 then
-        card.ability.extra.mult = card.ability.extra.mult + context.card.cost
-
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult',
-            vars = { context.card.cost }
-          },
-          colour = G.C.MULT
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_table = context.card,
+          scalar_value = 'cost',
+          message_key = 'a_mult',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/jacks.lua
+++ b/content/joker/jacks.lua
@@ -43,11 +43,12 @@ SMODS.Joker {
       }
     end
     if not context.blueprint and context.discard and PB_UTIL.is_rank(context.other_card, card.ability.extra.rank) then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.change
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.ORANGE
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'change'
+      })
+      return nil, true
     end
   end
 }

--- a/content/joker/jestrica.lua
+++ b/content/joker/jestrica.lua
@@ -51,16 +51,13 @@ SMODS.Joker {
     if not context.blueprint and context.individual and context.cardarea == G.play then
       if PB_UTIL.is_rank(context.other_card, card.ability.extra.rank) then
         card.ability.extra.scored = true
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.increase
-
-        return {
-          extra = {
-            focus = card,
-            message = localize('k_upgrade_ex'),
-            colour = G.C.MULT,
-          },
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'increase',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/joke_master.lua
+++ b/content/joker/joke_master.lua
@@ -37,16 +37,14 @@ SMODS.Joker {
     if not context.blueprint and context.before and context.main_eval then
       -- Check that scoring hand is exactly the one needed
       if context.scoring_name == G.GAME.paperback.joke_master_hand then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult',
-            vars = { card.ability.extra.mult }
-          },
-          colour = G.C.MULT
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'a_mult',
+          message_key = 'a_mult',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/joker_cookie.lua
+++ b/content/joker/joker_cookie.lua
@@ -66,12 +66,13 @@ SMODS.Joker {
       -- Upgrade the Joker when the user cashes out
       if context.paperback and context.paperback.cashing_out then
         if card.ability.extra.dollar_bonus < card.ability.extra.dollar_max then
-          card.ability.extra.dollar_bonus = card.ability.extra.dollar_bonus + card.ability.extra.dollar_gain
-
-          return {
-            message = localize('k_upgrade_ex'),
-            colour = G.C.MONEY
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'dollar_bonus',
+            scalar_value = 'dollar_gain',
+            message_colour = G.C.MONEY
+          })
+          return nil, true
         end
       end
     end

--- a/content/joker/joker_duty.lua
+++ b/content/joker/joker_duty.lua
@@ -40,11 +40,12 @@ SMODS.Joker {
     end
     if context.end_of_round and context.main_eval then
       if G.GAME.current_round.discards_left == G.GAME.current_round.hands_left then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.change
-        return {
-          message = localize("k_upgrade_ex"),
-          colour = G.C.ORANGE
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'change'
+        })
+        return nil, true
       end
     end
   end

--- a/content/joker/kintsugi_joker.lua
+++ b/content/joker/kintsugi_joker.lua
@@ -57,17 +57,21 @@ SMODS.Joker {
 
       for _, v in ipairs(context.removed) do
         if SMODS.has_enhancement(v, card.ability.extra.enhancement) then
-          inc = inc + card.ability.extra.increase
+          inc = inc + 1
         end
       end
 
       if inc > 0 then
-        G.GAME.paperback.ceramic_inc = G.GAME.paperback.ceramic_inc + inc
-        card.ability.extra.total = card.ability.extra.total + inc
-
-        return {
-          message = localize('k_upgrade_ex')
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'total',
+          scalar_value = 'increase',
+          operation = function(ref_table, ref_value, initial, scaling)
+            ref_table[ref_value] = initial + scaling * inc
+            G.GAME.paperback.ceramic_inc = G.GAME.paperback.ceramic_inc + scaling * inc
+          end
+        })
+        return nil, true
       end
     end
   end

--- a/content/joker/matcha.lua
+++ b/content/joker/matcha.lua
@@ -46,13 +46,13 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if not context.blueprint and context.individual and context.cardarea == G.play then
-      card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.a_chips
-
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.CHIPS,
-        card = card
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'a_chips',
+        message_colour = G.C.CHIPS
+      })
+      return nil, true
     end
 
     if not context.blueprint and context.pre_discard and not context.hook then

--- a/content/joker/mind_electric.lua
+++ b/content/joker/mind_electric.lua
@@ -47,11 +47,14 @@ SMODS.Joker {
     end
     if context.destroy_card and context.cardarea == G.play and not context.blueprint then
       if SMODS.has_enhancement(context.destroy_card, "m_mult") then
-        card.ability.extra.xm = card.ability.extra.xm + card.ability.extra.change
-        return {
-          message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.xm } },
-          remove = true
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'xm',
+          scalar_value = 'change',
+          message_key = 'a_xmult',
+          message_colour = G.C.MULT
+        })
+        return { remove = true }
       end
     end
   end,

--- a/content/joker/mismatched_sock.lua
+++ b/content/joker/mismatched_sock.lua
@@ -40,11 +40,12 @@ SMODS.Joker {
     -- Upgrade x mult if discard contains only one card
     if not context.blueprint and context.discard then
       if #context.full_hand == 1 then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.a_xmult
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.ORANGE
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'a_xmult'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/moribund.lua
+++ b/content/joker/moribund.lua
@@ -4,6 +4,7 @@ SMODS.Joker {
     extra = {
       a_mult = 5,
       mult = 0,
+      ax_mult = 2,
     }
   },
   attributes = {
@@ -41,22 +42,24 @@ SMODS.Joker {
       if context.end_of_round and context.main_eval then
         -- If blind not cleared, double current mult
         if to_big(G.GAME.chips - G.GAME.blind.chips) < to_big(0) then
-          card.ability.extra.mult = card.ability.extra.mult * 2
-
-          return {
-            message = localize('paperback_doubled_ex'),
-            colour = G.C.MULT,
-            card = card
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'mult',
+            scalar_value = 'ax_mult',
+            operation = 'X',
+            message_key = 'paperback_doubled_ex',
+            message_colour = G.C.MULT
+          })
+          return nil, true
         elseif G.GAME.current_round.hands_left == 0 then
           -- If blind cleared and 0 hands left, upgrade joker
-          card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-
-          return {
-            message = localize('k_upgrade_ex'),
-            card = card,
-            colour = G.C.MULT,
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'mult',
+            scalar_value = 'a_mult',
+            message_colour = G.C.MULT
+          })
+          return nil, true
         end
       end
     end

--- a/content/joker/moving_out.lua
+++ b/content/joker/moving_out.lua
@@ -55,12 +55,13 @@ SMODS.Joker {
         return
       end
 
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-      return {
-        message = localize('k_upgrade_ex'),
-        card = card,
-        colour = G.C.MULT,
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'a_mult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
 
     if context.joker_main then

--- a/content/joker/nachos.lua
+++ b/content/joker/nachos.lua
@@ -53,11 +53,8 @@ SMODS.Joker {
 
     -- Penalize discarding cards only when the current mult is higher than 1
     if context.discard and not context.blueprint and card.ability.extra.X_chips > 1 then
-      -- Reduce the xChips value
-      card.ability.extra.X_chips = card.ability.extra.X_chips - card.ability.extra.reduction_amount
-
       -- Destroy Nachos if the current value is <= 1
-      if card.ability.extra.X_chips <= 1 then
+      if card.ability.extra.X_chips - card.ability.extra.reduction_amount <= 1 then
         PB_UTIL.destroy_joker(card)
 
         return {
@@ -66,16 +63,16 @@ SMODS.Joker {
           card = card
         }
       else
-        return {
-          delay = 0.2,
-          message = localize {
-            type = 'variable',
-            key = 'a_xchips_minus',
-            vars = { card.ability.extra.reduction_amount }
-          },
-          colour = G.C.CHIPS,
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'X_chips',
+          scalar_value = 'reduction_amount',
+          operation = '-',
+          message_colour = G.C.CHIPS,
+          message_key = 'a_xchips_minus',
+          message_delay = 0.2
+        })
+        return nil, true
       end
     end
   end,

--- a/content/joker/nazar.lua
+++ b/content/joker/nazar.lua
@@ -43,11 +43,13 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.using_consumeable and not context.blueprint and (context.consumeable.ability.set == 'Tarot' or context.consumeable.ability.set == 'paperback_minor_arcana') then
-      card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chips_gain
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.CHIPS
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'chips_gain',
+        message_colour = G.C.CHIPS
+      })
+      return nil, true
     end
     if context.joker_main then
       return {

--- a/content/joker/off_alpha.lua
+++ b/content/joker/off_alpha.lua
@@ -53,16 +53,14 @@ SMODS.Joker {
     if not context.blueprint
     and context.paperback and context.paperback.destroyed_joker and not (card == context.paperback.destroyed_joker) and not (context.paperback.destroyed_joker.config.center.paperback and context.paperback.destroyed_joker.config.center.paperback.addon)
     then
-      card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chips_mod
-
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_chips',
-          vars = { card.ability.extra.chips_mod }
-        },
-        colour = G.C.CHIPS
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'chips_mod',
+        message_key = 'a_chips',
+        message_colour = G.C.CHIPS
+      })
+      return nil, true
     end
 
     if context.joker_main then

--- a/content/joker/off_omega.lua
+++ b/content/joker/off_omega.lua
@@ -53,16 +53,14 @@ SMODS.Joker {
     if not context.blueprint
     and context.paperback and context.paperback.destroyed_joker and not (card == context.paperback.destroyed_joker) and not (context.paperback.destroyed_joker.config.center.paperback and context.paperback.destroyed_joker.config.center.paperback.addon)
     then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
-
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_mult',
-          vars = { card.ability.extra.mult_mod }
-        },
-        colour = G.C.MULT
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_mod',
+        message_key = 'a_mult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
 
     if context.joker_main then

--- a/content/joker/off_switch.lua
+++ b/content/joker/off_switch.lua
@@ -105,15 +105,14 @@ SMODS.Joker {
 
     if not context.blueprint and context.paperback and context.paperback.destroyed_joker and
     not (card == context.paperback.destroyed_joker) then
-      card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.a_xmult
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_xmult',
-          vars = { card.ability.extra.a_xmult }
-        },
-        colour = G.C.MULT
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'x_mult',
+        scalar_value = 'a_xmult',
+        message_key = 'a_xmult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
 
     if context.joker_main then

--- a/content/joker/one_shift_more.lua
+++ b/content/joker/one_shift_more.lua
@@ -53,14 +53,19 @@ SMODS.Joker {
 
         if card.ability.extra.current >= card.ability.extra.required then
           card.ability.extra.current = 0
-          card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.a_xmult
           local key = 'paperback_one_shift_more_' .. tostring(card.ability.extra.odd)
           card.ability.extra.odd = not card.ability.extra.odd
-          return {
-            message = localize(key),
-            colour = G.C.MULT,
-            message_card = card
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'x_mult',
+            scalar_value = 'a_xmult',
+            scaling_message = {
+              message = localize(key),
+              colour = G.C.MULT,
+              message_card = card
+            }
+          })
+          return nil, true
         end
       end
     end

--- a/content/joker/park_postcard.lua
+++ b/content/joker/park_postcard.lua
@@ -37,10 +37,14 @@ SMODS.Joker {
       }
     end
     if context.end_of_round and context.main_eval and not context.blueprint then
-      card.ability.extra.xm = card.ability.extra.xm + card.ability.extra.change
-      return {
-        message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.xm } }
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xm',
+        scalar_value = 'change',
+        message_key = 'a_xmult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
     if context.playing_card_added or context.remove_playing_cards and not context.blueprint then
       card.ability.extra.xm = 1

--- a/content/joker/pear.lua
+++ b/content/joker/pear.lua
@@ -52,11 +52,13 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.before and not context.blueprint then
       if next(context.poker_hands['Pair']) then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_gain
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.CHIPS
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'chip_gain',
+          message_colour = G.C.CHIPS
+        })
+        return nil, true
       elseif card.ability.extra.chips < 10 then
         PB_UTIL.destroy_joker(card)
         return {
@@ -64,11 +66,14 @@ SMODS.Joker {
           colour = G.C.FILTER
         }
       else
-        card.ability.extra.chips = card.ability.extra.chips - card.ability.extra.chip_loss
-        return {
-          message = localize { type = 'variable', key = 'a_chips_minus', vars = { card.ability.extra.chip_loss } },
-          colour = G.C.CHIPS
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'chip_loss',
+          message_key = 'a_chips_minus',
+          message_colour = G.C.CHIPS
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/penumbra_phantasm.lua
+++ b/content/joker/penumbra_phantasm.lua
@@ -54,17 +54,14 @@ SMODS.Joker {
     -- Upgrade this Joker for every scored rankless card
     if not context.blueprint and context.individual and context.cardarea == G.play then
       if SMODS.has_no_rank(context.other_card) then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult',
-            vars = { card.ability.extra.mult },
-            colour = G.C.MULT,
-          },
-          message_card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'a_mult',
+          message_key = 'a_mult',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
   end,

--- a/content/joker/penumbra_phantasm.lua
+++ b/content/joker/penumbra_phantasm.lua
@@ -58,10 +58,17 @@ SMODS.Joker {
           ref_table = card.ability.extra,
           ref_value = 'mult',
           scalar_value = 'a_mult',
-          message_key = 'a_mult',
-          message_colour = G.C.MULT
+          no_message = true
         })
-        return nil, true
+        return {
+          message = localize {
+            type = 'variable',
+            key = 'a_mult',
+            vars = { card.ability.extra.mult },
+          },
+          colour = G.C.MULT,
+          message_card = card
+        }
       end
     end
   end,

--- a/content/joker/planchette.lua
+++ b/content/joker/planchette.lua
@@ -32,11 +32,13 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if not context.blueprint and context.using_consumeable and context.consumeable.ability.set == 'Spectral' then
-      card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_gain
-      return {
-        message = localize('k_upgrade_ex'),
-        colour = G.C.MULT,
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xmult',
+        scalar_value = 'xmult_gain',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
     if context.joker_main then
       return { xmult = card.ability.extra.xmult }

--- a/content/joker/pride_flag.lua
+++ b/content/joker/pride_flag.lua
@@ -62,13 +62,13 @@ if PB_UTIL.config.suits_enabled then
           }
           -- Give chips if hand contains a Spectrum
         elseif PB_UTIL.get_unique_suits(context.full_hand, nil, true) >= 5 then
-          card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.a_chips
-
-          SMODS.calculate_effect {
-            message = localize('k_upgrade_ex'),
-            colour = G.C.CHIPS,
-            card = card
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'chips',
+            scalar_value = 'a_chips',
+            message_colour = G.C.CHIPS
+          })
+          return nil, true
         end
       end
 
@@ -162,13 +162,13 @@ else
 
         -- If there are 3 unique suits, upgrade the joker
         if unique_suits >= 3 then
-          card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-
-          return {
-            message = localize('k_upgrade_ex'),
-            colour = G.C.MULT,
-            card = card
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'mult',
+            scalar_value = 'a_mult',
+            message_colour = G.C.MULT
+          })
+          return nil, true
         end
       end
 

--- a/content/joker/ready_to_fly.lua
+++ b/content/joker/ready_to_fly.lua
@@ -86,11 +86,12 @@ SMODS.Joker {
       end
 
       if (left_joker and context.other_card == left_joker) or (right_joker and context.other_card == right_joker) then
-        card.ability.extra.xchips = card.ability.extra.xchips + card.ability.extra.scaling
-        return {
-          message = localize('k_upgrade_ex'),
-          message_card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'xchips',
+          scalar_value = 'scaling'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/red_sun_in_the_sky.lua
+++ b/content/joker/red_sun_in_the_sky.lua
@@ -36,7 +36,12 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.individual and context.cardarea == G.play then
       if PB_UTIL.is_suit(context.other_card, 'light') then
-        if not context.blueprint then card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.change end
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'change',
+          no_message = true
+        })
         return {
           mult = card.ability.extra.mult
         }

--- a/content/joker/sacrificial_lamb.lua
+++ b/content/joker/sacrificial_lamb.lua
@@ -54,16 +54,23 @@ SMODS.Joker {
     -- Make sure that this joker isn't being removed
     and not (context.paperback and context.paperback.destroyed_joker and card == context.paperback.destroyed_joker)
     then
-      card.ability.extra.mult = card.ability.extra.mult + count * card.ability.extra.mult_mod
-
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_mult',
-          vars = { count * card.ability.extra.mult_mod }
-        },
-        colour = G.C.MULT
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_mod',
+        operation = function(ref_table, ref_value, initial, scaling)
+          ref_table[ref_value] = initial + scaling * count
+        end,
+        scaling_message = {
+          message = localize {
+            type = 'variable',
+            key = 'a_mult',
+            vars = { count * card.ability.extra.mult_mod }
+          },
+          colour = G.C.MULT
+        }
+      })
+      return nil, true
     end
 
     -- Gives the mult when scoring

--- a/content/joker/satellite_array.lua
+++ b/content/joker/satellite_array.lua
@@ -27,17 +27,26 @@ SMODS.Joker {
       }
     end
     if context.after and card.ability.extra.chips > 0 and not context.blueprint then
-      card.ability.extra.chips = card.ability.extra.chips - card.ability.extra.chips_rem
-      return {
-        message = localize('paperback_downgrade_ex'),
-        colour = G.C.ORANGE
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'chips_rem',
+        operation = '-',
+        scaling_message = {
+          message = localize('paperback_downgrade_ex'),
+          colour = G.C.ORANGE
+        }
+      })
+      return nil, true
     end
     if context.using_consumeable and not context.blueprint and context.consumeable.ability.set == 'Planet' then
-      card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chips_mod
-      return {
-        message = localize { type = 'variable', key = 'a_chips', vars = { card.ability.extra.chips } }
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'chips_mod',
+        message_key = 'a_chips'
+      })
+      return nil, true
     end
   end,
 

--- a/content/joker/silent_assassin.lua
+++ b/content/joker/silent_assassin.lua
@@ -51,13 +51,16 @@ SMODS.Joker {
     if context.remove_playing_cards and not context.blueprint then
       local destroyed = card.ability.extra.destroyed + #context.removed
       card.ability.extra.destroyed = destroyed % card.ability.extra.destroy_req
-      local change = math.floor(destroyed / card.ability.extra.destroy_req) * card.ability.extra.change
-      card.ability.extra.mult = card.ability.extra.mult + change
-      if change > 0 then
-        return {
-          message = localize('k_upgrade_ex')
-        }
-      end
+      local change = math.floor(destroyed / card.ability.extra.destroy_req)
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'change',
+        operation = function(ref_table, ref_value, initial, scaling)
+          ref_table[ref_value] = initial + scaling * change
+        end
+      })
+      return nil, true
     end
   end
 }

--- a/content/joker/small_scale_onshore_wind.lua
+++ b/content/joker/small_scale_onshore_wind.lua
@@ -36,11 +36,12 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.pre_discard and not context.hook and not context.blueprint_card then
       if #context.full_hand == card.ability.extra.card_req then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.bonus
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.ORANGE
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'bonus'
+        })
+        return nil, true
       else
         card.ability.extra.mult = 0
         return {

--- a/content/joker/solemn_lament.lua
+++ b/content/joker/solemn_lament.lua
@@ -67,7 +67,6 @@ SMODS.Joker {
 
       if suits.dark + suits.light + suits.wild >= 2 then
         local BGcolour
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.x_mult_mod
         if card.ability.extra.is_white then
           BGcolour = G.C.BLACK
           card.ability.extra.is_white = false
@@ -75,14 +74,14 @@ SMODS.Joker {
           BGcolour = G.C.PAPERBACK_SOLEMN_WHITE
           card.ability.extra.is_white = true
         end
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_xmult',
-            vars = { card.ability.extra.x_mult }
-          },
-          colour = BGcolour
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'x_mult_mod',
+          message_key = 'a_xmult',
+          message_colour = BGcolour
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/spotty_joker.lua
+++ b/content/joker/spotty_joker.lua
@@ -47,17 +47,22 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.before and not context.blueprint then
-      local upgraded
+      local upgrade = 0
       for _, v in ipairs(context.scoring_hand) do
         if SMODS.has_enhancement(v, 'm_paperback_domino') then
-          card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
-          upgraded = true
+          upgrade = upgrade + 1
         end
       end
-      if upgraded then
-        return {
-          message = localize('k_upgrade_ex'),
-        }
+      if upgrade > 0 then
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'xmult',
+          scalar_value = 'xmult_mod',
+          operation = function(ref_table, ref_value, initial, scaling)
+            ref_table[ref_value] = initial + scaling * upgrade
+          end
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/stamp.lua
+++ b/content/joker/stamp.lua
@@ -77,10 +77,13 @@ SMODS.Joker {
         if context.other_card:get_seal() then
           -- Gives chips if roll succeeds
           if PB_UTIL.chance(card, 'stamp', card.ability.extra.numerator, card.ability.extra.denominator) then
-            card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_mod
-
-            card_eval_status_text(card, 'extra', nil, nil, nil,
-              { message = localize('k_upgrade_ex'), colour = G.C.CHIPS })
+            SMODS.scale_card(card, {
+              ref_table = card.ability.extra,
+              ref_value = 'chips',
+              scalar_value = 'chip_mod',
+              message_colour = G.C.CHIPS
+            })
+            return nil, true
           end
         end
       end

--- a/content/joker/surfer.lua
+++ b/content/joker/surfer.lua
@@ -41,18 +41,22 @@ SMODS.Joker {
     -- Gains +10 chips for each 10 held in hand at end of round
     if context.end_of_round and context.individual and context.cardarea == G.hand and not context.blueprint then
       if PB_UTIL.is_rank(context.other_card, card.ability.extra.rank) then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.a_chips_held
-
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_chips',
-            vars = { card.ability.extra.a_chips_held }
-          },
-          colour = G.C.CHIPS,
-          juice_card = context.other_card,
-          message_card = card,
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'a_chips_held',
+          scaling_message = {
+            message = localize {
+              type = 'variable',
+              key = 'a_chips',
+              vars = { card.ability.extra.a_chips_held }
+            },
+            colour = G.C.CHIPS,
+            juice_card = context.other_card,
+            message_card = card,
+          }
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/teapot.lua
+++ b/content/joker/teapot.lua
@@ -50,15 +50,13 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.individual and context.cardarea == G.play and not context.blueprint then
       if SMODS.has_enhancement(context.other_card, card.ability.extra.enhancement) then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.a_chips
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_chips',
-            vars = { card.ability.extra.chips },
-            colour = G.C.FILTER,
-          },
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'a_chips',
+          message_key = 'a_chips'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/the_one_who_waits.lua
+++ b/content/joker/the_one_who_waits.lua
@@ -69,16 +69,14 @@ SMODS.Joker {
         local effects
 
         if not context.blueprint and PB_UTIL.chance(card, "the_one_who_waits_upgrade", nil, card.ability.extra.upgrade_odds) then
-          card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.x_mult_mod
-
-          effects = {
-            message = localize {
-              type = 'variable',
-              key = 'a_xmult',
-              vars = { card.ability.extra.x_mult }
-            },
-            colour = G.C.MULT
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'x_mult',
+            scalar_value = 'x_mult_mod',
+            message_key = 'a_xmult',
+            message_colour = G.C.MULT
+          })
+          return nil, true
         end
 
         if PB_UTIL.chance(card, "the_one_who_waits_tarot", nil, card.ability.extra.tarot_odds) then

--- a/content/joker/the_strongest.lua
+++ b/content/joker/the_strongest.lua
@@ -54,15 +54,14 @@ SMODS.Joker {
   calculate = function(self, card, context)
     -- Upgrade when a sin is activated
     if context.paperback and context.paperback.sold_ego_gift then
-      card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_xmult',
-          vars = { card.ability.extra.xmult }
-        },
-        colour = G.C.RED
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xmult',
+        scalar_value = 'xmult_mod',
+        message_key = 'a_xmult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
 
     if context.end_of_round and context.cardarea == G.jokers and G.GAME.blind.boss then

--- a/content/joker/the_sun.lua
+++ b/content/joker/the_sun.lua
@@ -45,30 +45,28 @@ SMODS.Joker {
         bad_suit = bad_suit or PB_UTIL.is_non_suit(v, 'light')
       end
       if not bad_suit then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult',
-            vars = { card.ability.extra.a_mult }
-          },
-          colour = G.C.FILTER
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'a_mult',
+          message_key = 'a_mult'
+        })
+        return nil, true
       end
     end
 
     if context.individual and context.cardarea == G.play and not context.blueprint then
       if card.ability.extra.mult > 0 then
         if PB_UTIL.is_non_suit(context.other_card, 'light') then
-          card.ability.extra.mult = card.ability.extra.mult - card.ability.extra.a_mult
-          return {
-            message = localize {
-              type = 'variable',
-              key = 'a_mult_minus',
-              vars = { card.ability.extra.a_mult },
-              colour = G.C.MULT
-            }
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'mult',
+            scalar_value = 'a_mult',
+            operation = '-',
+            message_key = 'a_mult_minus',
+            message_colour = G.C.MULT
+          })
+          return nil, true
         end
       end
     end

--- a/content/joker/the_sun_rises.lua
+++ b/content/joker/the_sun_rises.lua
@@ -52,7 +52,12 @@ SMODS.Joker {
     and PB_UTIL.is_suit(context.other_card, 'light') then
       local chips = card.ability.extra.chips
       if not context.blueprint then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chip_inc_per_light
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'chip_inc_per_light',
+          no_message = true
+        })
       end
       return {
         chips = chips

--- a/content/joker/tian_tian.lua
+++ b/content/joker/tian_tian.lua
@@ -41,10 +41,17 @@ SMODS.Joker {
   calculate = function(self, card, context)
     -- Gains x_mult when playing cards are destroyed. Each card destroyed provides the specified xmult_mod
     if not context.blueprint and context.remove_playing_cards and context.removed and #context.removed > 0 then
-      card.ability.extra.x_mult = card.ability.extra.x_mult + (#context.removed * card.ability.extra.a_xmult)
-
-      card_eval_status_text(card, 'extra', nil, nil, nil,
-        { message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.x_mult } } })
+      local scale = #context.removed
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'x_mult',
+        scalar_value = 'a_xmult',
+        operation = function(ref_table, ref_value, initial, scaling)
+          ref_table[ref_value] = initial + scaling * scale
+        end,
+        message_key = 'a_xmult'
+      })
+      return nil, true
     end
 
     -- Gives the x_mult when scoring

--- a/content/joker/time_regression_mix.lua
+++ b/content/joker/time_regression_mix.lua
@@ -39,15 +39,13 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.before and not context.blueprint then
       if PB_UTIL.get_unique_suits(context.scoring_hand, false, true) >= card.ability.extra.suits then
-        card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.a_mult
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_mult',
-            vars = { card.ability.extra.a_mult }
-          },
-          colour = G.C.FILTER
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'mult',
+          scalar_value = 'a_mult',
+          message_key = 'a_mult'
+        })
+        return nil, true
       end
     end
 

--- a/content/joker/unholy_alliance.lua
+++ b/content/joker/unholy_alliance.lua
@@ -54,7 +54,7 @@ SMODS.Joker {
           message = localize {
             type = 'variable',
             key = 'a_chips',
-            vars = { count * card.ability.extra.mult_mod }
+            vars = { count * card.ability.extra.a_chips }
           },
           colour = G.C.CHIPS
         }

--- a/content/joker/unholy_alliance.lua
+++ b/content/joker/unholy_alliance.lua
@@ -43,16 +43,23 @@ SMODS.Joker {
     -- Make sure that this joker isn't being removed
     and not (context.paperback and context.paperback.destroyed_joker and card == context.paperback.destroyed_joker)
     then
-      card.ability.extra.chips = card.ability.extra.chips + count * card.ability.extra.a_chips
-
-      return {
-        message = localize {
-          type = 'variable',
-          key = 'a_chips',
-          vars = { count * card.ability.extra.a_chips }
-        },
-        colour = G.C.CHIPS
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'chips',
+        scalar_value = 'a_chips',
+        operation = function(ref_table, ref_value, initial, scaling)
+          ref_table[ref_value] = initial + scaling * count
+        end,
+        scaling_message = {
+          message = localize {
+            type = 'variable',
+            key = 'a_chips',
+            vars = { count * card.ability.extra.mult_mod }
+          },
+          colour = G.C.CHIPS
+        }
+      })
+      return nil, true
     end
 
     -- Gives the chips when scoring

--- a/content/joker/watermelon.lua
+++ b/content/joker/watermelon.lua
@@ -40,29 +40,40 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if not context.blueprint and context.setting_ability and context.other_card.ability.set == 'Enhanced' and not context.unchanged then
-      card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.a_xmult
-      return {
-        message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.a_xmult } },
-        colour = G.C.MULT
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'x_mult',
+        scalar_value = 'a_xmult',
+        message_key = 'a_xmult',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
     if not context.blueprint and context.remove_playing_cards and #context.removed > 0 then
-      card.ability.extra.x_mult = card.ability.extra.x_mult - (card.ability.extra.a_xmult * #context.removed)
-      if card.ability.extra.x_mult < 1 then
+      if card.ability.extra.x_mult - (card.ability.extra.a_xmult * #context.removed) < 1 then
         PB_UTIL.destroy_joker(card)
         return {
           message = localize('k_eaten_ex'),
           colour = G.C.FILTER
         }
       else
-        return {
-          message = localize {
-            type = 'variable',
-            key = 'a_xmult_minus',
-            vars = { card.ability.extra.a_xmult * #context.removed }
-          },
-          colour = G.C.MULT
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'a_xmult',
+          operation = function(ref_table, ref_value, initial, scaling)
+            ref_table[ref_value] = initial - scaling * #context.removed
+          end,
+          scaling_message = {
+            message = localize {
+              type = 'variable',
+              key = 'a_xmult_minus',
+              vars = { card.ability.extra.a_xmult * #context.removed }
+            },
+            colour = G.C.MULT
+          }
+        })
+        return nil, true
       end
     end
     if context.cardarea == G.jokers and context.joker_main then

--- a/content/joker/weather_radio.lua
+++ b/content/joker/weather_radio.lua
@@ -45,10 +45,21 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if not context.blueprint and context.before then
       if next(context.poker_hands[G.GAME.paperback.weather_radio_hand]) then
-        card.ability.extra.x_mult = card.ability.extra.x_mult + card.ability.extra.a_xmult
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'a_xmult',
+          no_message = true
+        })
 
         if G.GAME.blind.boss and not G.GAME.blind.disabled and card.ability.extra.x_mult >= card.ability.extra.xmult_disable then
-          card.ability.extra.x_mult = card.ability.extra.x_mult - card.ability.extra.xmult_penalty
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'x_mult',
+            scalar_value = 'xmult_penalty',
+            operation = '-',
+            no_message = true
+          })
 
           return {
             message = localize('ph_boss_disabled'),
@@ -71,7 +82,13 @@ SMODS.Joker {
 
     if not context.blueprint and context.first_hand_drawn and G.GAME.blind.boss and not G.GAME.blind.disabled then
       if card.ability.extra.x_mult >= card.ability.extra.xmult_disable then
-        card.ability.extra.x_mult = card.ability.extra.x_mult - card.ability.extra.xmult_penalty
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'x_mult',
+          scalar_value = 'xmult_penalty',
+          operation = '-',
+          no_message = true
+        })
 
         G.GAME.blind:disable()
 

--- a/content/joker/wish_you_were_here.lua
+++ b/content/joker/wish_you_were_here.lua
@@ -47,12 +47,18 @@ SMODS.Joker {
 
     -- Increase the sell value at end of round
     if context.end_of_round and not context.blueprint and context.main_eval then
-      PB_UTIL.modify_sell_value(card, 1)
-
-      return {
-        message = localize('k_val_up'),
-        colour = G.C.MONEY
-      }
+      SMODS.scale_card(card, {
+        ref_table = card.ability,
+        ref_value = 'extra_value',
+        scalar_table = card.ability.extra,
+        scalar_value = 'sv_gain',
+        scaling_message = {
+          message = localize('k_val_up'),
+          colour = G.C.MONEY
+        }
+      })
+      card:set_cost()
+      return nil, true
     end
   end,
 

--- a/content/joker/yacht.lua
+++ b/content/joker/yacht.lua
@@ -52,11 +52,12 @@ if PB_UTIL.should_load_spectrum_items() then
           end
         end
         if suit_count > 0 then
-          card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.change
-          return {
-            message = localize("k_upgrade_ex"),
-            colour = G.C.ORANGE
-          }
+          SMODS.scale_card(card, {
+            ref_table = card.ability.extra,
+            ref_value = 'chips',
+            scalar_value = 'change'
+          })
+          return nil, true
         end
       end
       if context.joker_main and card.ability.extra.chips > 0 then

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -4276,6 +4276,7 @@ return {
       paperback_a_plus_cards = "+#1# #2#s",
       paperback_a_plus_tags = "+#1# Tags",
       paperback_a_dollars = "$#1#",
+      paperback_a_odds = "+#1# Odds",
 
       paperback_a_plus_consumable_slot = "+#1# Consumable Slots",
       paperback_a_minus_consumable_slot = "-#1# Consumable Slots",

--- a/utilities/misc_functions.lua
+++ b/utilities/misc_functions.lua
@@ -997,7 +997,12 @@ function PB_UTIL.panorama_logic(self, card, context)
       local xMult = card.ability.extra.xMult
       -- Upgrade the xMult if not blueprint
       if not context.blueprint then
-        card.ability.extra.xMult = card.ability.extra.xMult + card.ability.extra.xMult_gain
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'xMult',
+          scalar_value = 'xMult_gain',
+          no_message = true
+        })
       end
 
       return {


### PR DESCRIPTION
- doesn't implement it for Attacking Vertical or Joker Duty yet, because of formatting changes i have on a different branch that'd cause a conflict if i changed stuff here
- legacy does not use it because it does not have a scalar variable
- yacht dice does not use it because it's retroactive scaling and i thiiiink that's a case you wouldn't use it?
- did not test Pride Flag (spectrum version), The One Who Waits, The Strongest, or Yacht because of features i have disabled. they probably work though