### PR TITLE
random enhancements exclude rankless

### DIFF
--- a/content/joker/double_dutchman.lua
+++ b/content/joker/double_dutchman.lua
@@ -48,6 +48,7 @@ SMODS.Joker {
         if PB_UTIL.chance(card, 'dd_enhancement_roll') and v.ability.set ~= 'Enhanced' then
           local enhancement = SMODS.poll_enhancement {
             key = 'dd_enhancement',
+            no_replace = true,
             guaranteed = true
           }
 

--- a/content/joker/double_dutchman.lua
+++ b/content/joker/double_dutchman.lua
@@ -48,7 +48,7 @@ SMODS.Joker {
         if PB_UTIL.chance(card, 'dd_enhancement_roll') and v.ability.set ~= 'Enhanced' then
           local enhancement = SMODS.poll_enhancement {
             key = 'dd_enhancement',
-            no_replace = true,
+            options = PB_UTIL.get_ranked_enhancements(),
             guaranteed = true
           }
 

--- a/content/joker/mandela_effect.lua
+++ b/content/joker/mandela_effect.lua
@@ -34,6 +34,7 @@ SMODS.Joker {
       if not first_face.debuff then
         local enhancement = SMODS.poll_enhancement {
           key = 'mandela_effect_enh',
+          no_replace = true,
           guaranteed = true
         }
         first_face:set_ability(enhancement, nil, true)

--- a/content/joker/mandela_effect.lua
+++ b/content/joker/mandela_effect.lua
@@ -34,7 +34,7 @@ SMODS.Joker {
       if not first_face.debuff then
         local enhancement = SMODS.poll_enhancement {
           key = 'mandela_effect_enh',
-          no_replace = true,
+          options = PB_UTIL.get_ranked_enhancements(),
           guaranteed = true
         }
         first_face:set_ability(enhancement, nil, true)

--- a/content/minor_arcana/five_of_swords.lua
+++ b/content/minor_arcana/five_of_swords.lua
@@ -53,7 +53,7 @@ PB_UTIL.MinorArcana {
       elseif modifier == 'enhancement' then
         local enhancement = SMODS.poll_enhancement {
           key = 'five_of_swords_enhancement',
-          no_replace = true,
+          options = PB_UTIL.get_ranked_enhancements(),
           guaranteed = true
         }
 

--- a/content/minor_arcana/five_of_swords.lua
+++ b/content/minor_arcana/five_of_swords.lua
@@ -53,6 +53,7 @@ PB_UTIL.MinorArcana {
       elseif modifier == 'enhancement' then
         local enhancement = SMODS.poll_enhancement {
           key = 'five_of_swords_enhancement',
+          no_replace = true,
           guaranteed = true
         }
 

--- a/content/minor_arcana/seven_of_cups.lua
+++ b/content/minor_arcana/seven_of_cups.lua
@@ -22,7 +22,7 @@ PB_UTIL.MinorArcana {
       for _, v in ipairs(G.hand.highlighted) do
         local enhancement = SMODS.poll_enhancement {
           type_key = 'seven_of_cups',
-          no_replace = true,
+          options = PB_UTIL.get_ranked_enhancements(),
           guaranteed = true
         }
 

--- a/content/minor_arcana/seven_of_cups.lua
+++ b/content/minor_arcana/seven_of_cups.lua
@@ -22,6 +22,7 @@ PB_UTIL.MinorArcana {
       for _, v in ipairs(G.hand.highlighted) do
         local enhancement = SMODS.poll_enhancement {
           type_key = 'seven_of_cups',
+          no_replace = true,
           guaranteed = true
         }
 

--- a/utilities/misc_functions.lua
+++ b/utilities/misc_functions.lua
@@ -1401,3 +1401,14 @@ function PB_UTIL.count_entries(table)
   for _ in pairs(table) do count = count + 1 end
   return count
 end
+
+--- Get a list of all non-rankless enhancement keys (based on logic from spectrals)
+function PB_UTIL.get_ranked_enhancements()
+  local cen_pool = {}
+  for i, key in ipairs(get_current_pool('Enhanced')) do
+    if key ~= "UNAVAILABLE" and key ~= 'm_stone' and not G.P_CENTERS[key].overrides_base_rank then
+      cen_pool[#cen_pool + 1] = key
+    end
+  end
+  return cen_pool
+end


### PR DESCRIPTION
adds `PB_UTIL.get_ranked_enhancements()` to get a list of acceptable enhancements (`no_replace` argument doesn't work)